### PR TITLE
Fix duplicated songs

### DIFF
--- a/Rise Media Player Dev/ViewModels/MainViewModel.cs
+++ b/Rise Media Player Dev/ViewModels/MainViewModel.cs
@@ -170,7 +170,8 @@ namespace Rise.App.ViewModels
                 Songs.Clear();
                 foreach (Song s in songs)
                 {
-                    Songs.Add(new SongViewModel(s));
+                    if(!songs.Contains(s))
+                        Songs.Add(new SongViewModel(s));
                 }
 
                 Albums.Clear();
@@ -178,7 +179,8 @@ namespace Rise.App.ViewModels
                 {
                     foreach (Album a in albums)
                     {
-                        Albums.Add(new AlbumViewModel(a));
+                        if(!albums.Contains(a))
+                            Albums.Add(new AlbumViewModel(a));
                     }
                 }
 
@@ -187,7 +189,8 @@ namespace Rise.App.ViewModels
                 {
                     foreach (Artist a in artists)
                     {
-                        Artists.Add(new ArtistViewModel(a));
+                        if(!artists.Contains(a))
+                            Artists.Add(new ArtistViewModel(a));
                     }
                 }
 
@@ -196,7 +199,8 @@ namespace Rise.App.ViewModels
                 {
                     foreach (Genre g in genres)
                     {
-                        Genres.Add(new GenreViewModel(g));
+                        if(!genres.Contains(g))
+                            Genres.Add(new GenreViewModel(g));
                     }
                 }
 
@@ -205,7 +209,8 @@ namespace Rise.App.ViewModels
                 {
                     foreach (Video v in videos)
                     {
-                        Videos.Add(new VideoViewModel(v));
+                        if(!videos.Contains(v))
+                            Videos.Add(new VideoViewModel(v));
                     }
                 }
 
@@ -214,7 +219,8 @@ namespace Rise.App.ViewModels
                 {
                     foreach (Playlist p in playlists)
                     {
-                        Playlists.Add(new PlaylistViewModel(p));
+                        if(!playlists.Contains(p))
+                            Playlists.Add(new PlaylistViewModel(p));
                     }
                 }
             }


### PR DESCRIPTION
## What? 
Prevents duplicated songs on songs, artist, albums and genres.

This fixes the issue #70 and #76

## Why?
It duplicates the same songs over and over again.

## How?
When `GetListsAsync` look for changes it adds again the same songs from the IEnumerables.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/33299343/147301050-9f015aa5-8769-4cec-82ea-cd8a39755114.png)
### After
![image](https://user-images.githubusercontent.com/33299343/147300865-c5d999e1-c103-4b6d-be15-c26f5e6a2055.png)
