### PR TITLE
Changed how the current synced lyric item is detected.

### DIFF
--- a/Rise Media Player Dev/Windows/NowPlayingPage.xaml.cs
+++ b/Rise Media Player Dev/Windows/NowPlayingPage.xaml.cs
@@ -151,20 +151,7 @@ namespace Rise.App.Views
 
         private IAsyncAction UpdateCurrentLyricAsync(TimeSpan playerPosition)
         {
-            var lyricsItem = new SyncedLyricItem();
-
-            if (_lyrics != null)
-            {
-                foreach (var item in _lyrics)
-                {
-                    if (item.TimeSpan.TotalMilliseconds < playerPosition.TotalMilliseconds)
-                    {
-                        lyricsItem = item;
-                    }
-                    else
-                        break;
-                }
-            }
+            var lyricsItem = _lyrics?.LastOrDefault(item => item.TimeSpan.TotalMilliseconds < playerPosition.TotalMilliseconds);
 
             // The dispatcher call starts here due to wrong thread exceptions when
             // trying to access the lyric list's SelectedItem normally

--- a/Rise Media Player Dev/Windows/NowPlayingPage.xaml.cs
+++ b/Rise Media Player Dev/Windows/NowPlayingPage.xaml.cs
@@ -151,7 +151,20 @@ namespace Rise.App.Views
 
         private IAsyncAction UpdateCurrentLyricAsync(TimeSpan playerPosition)
         {
-            var lyricsItem = _lyrics?.FirstOrDefault(item => item.TimeSpan.TotalSeconds - playerPosition.TotalSeconds >= 0);
+            var lyricsItem = new SyncedLyricItem();
+
+            if (_lyrics != null)
+            {
+                foreach (var item in _lyrics)
+                {
+                    if (item.TimeSpan.TotalMilliseconds < playerPosition.TotalMilliseconds)
+                    {
+                        lyricsItem = item;
+                    }
+                    else
+                        break;
+                }
+            }
 
             // The dispatcher call starts here due to wrong thread exceptions when
             // trying to access the lyric list's SelectedItem normally

--- a/Rise Media Player Dev/Windows/NowPlayingPage.xaml.cs
+++ b/Rise Media Player Dev/Windows/NowPlayingPage.xaml.cs
@@ -151,7 +151,7 @@ namespace Rise.App.Views
 
         private IAsyncAction UpdateCurrentLyricAsync(TimeSpan playerPosition)
         {
-            var lyricsItem = _lyrics?.LastOrDefault(item => item.TimeSpan.TotalMilliseconds < playerPosition.TotalMilliseconds);
+            var lyricsItem = _lyrics?.LastOrDefault(item => item.TimeSpan.TotalSeconds < playerPosition.TotalSeconds);
 
             // The dispatcher call starts here due to wrong thread exceptions when
             // trying to access the lyric list's SelectedItem normally


### PR DESCRIPTION
**Resolved / Related Issues**
Before, the current item was ahead. Now it is not.

**Details of Changes**
This pull request modified how the current synced lyric item is detected.
Before it was the first item with a time span greater than the player position.
Now it's the last item with a time span less than the player position.

**Validation**
How did you test these changes?
- [x] Built and ran the app
